### PR TITLE
2000 data

### DIFF
--- a/Data_2000/Dual_Graphs/Tract2000_01.json
+++ b/Data_2000/Dual_Graphs/Tract2000_01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f4cf1c349fb9b6485f0c5608c1ee7754983e4d176a2133d7807b3798563c5f2
+size 1212599

--- a/Data_2000/Dual_Graphs/Tract2000_02.json
+++ b/Data_2000/Dual_Graphs/Tract2000_02.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a99c4d47d1b4e79fa8bd206d514de106b06bbe84c8f663bb46a56b7c736a342c
+size 171044

--- a/Data_2000/Dual_Graphs/Tract2000_04.json
+++ b/Data_2000/Dual_Graphs/Tract2000_04.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554f6ca299a1d54e1691d16b56c57e3f9eb5f6333cf64c46d71e1922107fe01b
+size 1215057

--- a/Data_2000/Dual_Graphs/Tract2000_05.json
+++ b/Data_2000/Dual_Graphs/Tract2000_05.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af58ecdd72c174de78da185da3bf6abd499df9bf0fe200af0895653da004661b
+size 697295

--- a/Data_2000/Dual_Graphs/Tract2000_06.json
+++ b/Data_2000/Dual_Graphs/Tract2000_06.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:421be31780aa541267870caf86a70dea471fe993b9c5432c35ffbcfaef75802a
+size 7887446

--- a/Data_2000/Dual_Graphs/Tract2000_08.json
+++ b/Data_2000/Dual_Graphs/Tract2000_08.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e54ab97054c8eb53cfd4bcd370e85a0b1ba625ec975abeb0b78c77d625fc58c
+size 1178533

--- a/Data_2000/Dual_Graphs/Tract2000_09.json
+++ b/Data_2000/Dual_Graphs/Tract2000_09.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9443b7eff5b5f9646ae9998cbd287086cea10dac71c25f3b3f60b9fe6eaa9e6
+size 912270

--- a/Data_2000/Dual_Graphs/Tract2000_10.json
+++ b/Data_2000/Dual_Graphs/Tract2000_10.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fb2983674572e24703b819e93a46e3b9d2c541b3d881ac9d9d8f1908cafaaa
+size 217676

--- a/Data_2000/Dual_Graphs/Tract2000_11.json
+++ b/Data_2000/Dual_Graphs/Tract2000_11.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d0b33d9fd088305c412d09ee1f76bea728086cbaeea6d7bbb85f66e59c00583
+size 211418

--- a/Data_2000/Dual_Graphs/Tract2000_12.json
+++ b/Data_2000/Dual_Graphs/Tract2000_12.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb60ab681d5c2506b1bc3b149db058fb7c0887152736fae4d9d8af2bd40286f6
+size 3479817

--- a/Data_2000/Dual_Graphs/Tract2000_13.json
+++ b/Data_2000/Dual_Graphs/Tract2000_13.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d7203ab5310f977e930181ed664beb158ef9e2f15653a429b973aff669ca04b
+size 1815304

--- a/Data_2000/Dual_Graphs/Tract2000_15.json
+++ b/Data_2000/Dual_Graphs/Tract2000_15.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:927218fceff89c8bb91af43b69cc89c8fa8cff6781862ed108452f08b688b245
+size 313047

--- a/Data_2000/Dual_Graphs/Tract2000_16.json
+++ b/Data_2000/Dual_Graphs/Tract2000_16.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b0bfd148f60de272f35915026825a2addd608f45b739b858d94788cfb587b7b
+size 311128

--- a/Data_2000/Dual_Graphs/Tract2000_17.json
+++ b/Data_2000/Dual_Graphs/Tract2000_17.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fa16ad29aba854252d16bab42cdd552ad1a77a0bd86cd575c12c73d14199065
+size 3269410

--- a/Data_2000/Dual_Graphs/Tract2000_18.json
+++ b/Data_2000/Dual_Graphs/Tract2000_18.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e555ec0373b92da9657346a30ee8a2e2c6fc2ae1b99bb2ff932165983e9911e7
+size 1571712

--- a/Data_2000/Dual_Graphs/Tract2000_19.json
+++ b/Data_2000/Dual_Graphs/Tract2000_19.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b267fe7044c9673c58512c9d8039d89009cbd483c829ac0e6003f5dc07a0461
+size 873386

--- a/Data_2000/Dual_Graphs/Tract2000_20.json
+++ b/Data_2000/Dual_Graphs/Tract2000_20.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0fe716ea2df4e66a4a4e4303603d6c6a20916a780e45463ec232d110a219de8
+size 803539

--- a/Data_2000/Dual_Graphs/Tract2000_21.json
+++ b/Data_2000/Dual_Graphs/Tract2000_21.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:911e9a3240326c080ae01c0bc2783a9afd3960ee5a969873aa9866479e722a7d
+size 1113251

--- a/Data_2000/Dual_Graphs/Tract2000_22.json
+++ b/Data_2000/Dual_Graphs/Tract2000_22.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58a5c1722accedb6b4ea18391850d13aa28fb5a53d5fafbef76475f08e5137f3
+size 1241245

--- a/Data_2000/Dual_Graphs/Tract2000_23.json
+++ b/Data_2000/Dual_Graphs/Tract2000_23.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63e04ce2cb099f2c38f8b1aacd259032b04b9686c0e3af512445be8e9b49b3ff
+size 380128

--- a/Data_2000/Dual_Graphs/Tract2000_24.json
+++ b/Data_2000/Dual_Graphs/Tract2000_24.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb6bee43910e134de23210fd84e810964da146264cb5c3bbc21e63f97cb938e9
+size 1346993

--- a/Data_2000/Dual_Graphs/Tract2000_25.json
+++ b/Data_2000/Dual_Graphs/Tract2000_25.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d2c92e1f488504c240140f913fd1e7b2f84f3fb3acb192873501ae5ae6721f
+size 1529812

--- a/Data_2000/Dual_Graphs/Tract2000_26.json
+++ b/Data_2000/Dual_Graphs/Tract2000_26.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7037acccae6a7fec496f4099d0a5e15e9878badde3dedadf91bae8d07e4ba75
+size 2986118

--- a/Data_2000/Dual_Graphs/Tract2000_27.json
+++ b/Data_2000/Dual_Graphs/Tract2000_27.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73390b2030f25fe16da88c3319d5c8cc4ee4b1e86eb66ab00972ba0684ce81d9
+size 1449339

--- a/Data_2000/Dual_Graphs/Tract2000_28.json
+++ b/Data_2000/Dual_Graphs/Tract2000_28.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7742a8a4bfa34b2c73a18fbfdd3122e9e8588cd04002d5518f1247b30e665455
+size 673916

--- a/Data_2000/Dual_Graphs/Tract2000_29.json
+++ b/Data_2000/Dual_Graphs/Tract2000_29.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36b148fbb953548a9b79481306f48fe961305a6ccd6b8dfa2b070e9ac562c905
+size 1469282

--- a/Data_2000/Dual_Graphs/Tract2000_30.json
+++ b/Data_2000/Dual_Graphs/Tract2000_30.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2111e97cbcafd9ab646ad2ad47a33054565f162c2f9837ce3c7a0c2f24ae4bab
+size 298915

--- a/Data_2000/Dual_Graphs/Tract2000_31.json
+++ b/Data_2000/Dual_Graphs/Tract2000_31.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72c75ae4bac42c6d17429498672c5f656e4b31d023c9a5f1bdc458a05b2021ec
+size 555860

--- a/Data_2000/Dual_Graphs/Tract2000_32.json
+++ b/Data_2000/Dual_Graphs/Tract2000_32.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b34709e1c888d29367e868a336aff021dca5253cb94c51b89e1ea21f188a15a6
+size 534139

--- a/Data_2000/Dual_Graphs/Tract2000_33.json
+++ b/Data_2000/Dual_Graphs/Tract2000_33.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43f6557b3c1020484b3aa3610d35eff1dbfb7c8e0522e304b108fa45e811c130
+size 304925

--- a/Data_2000/Dual_Graphs/Tract2000_34.json
+++ b/Data_2000/Dual_Graphs/Tract2000_34.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae5f78dcb927e00827770cd7600bbe5e1c713aeaef1960b583eaf26190de79b
+size 2171707

--- a/Data_2000/Dual_Graphs/Tract2000_35.json
+++ b/Data_2000/Dual_Graphs/Tract2000_35.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e688bab0c67f4e0e1430be262fa2ec921e1ceb2dc835e5691efae1d09efb9a52
+size 507799

--- a/Data_2000/Dual_Graphs/Tract2000_36.json
+++ b/Data_2000/Dual_Graphs/Tract2000_36.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47c6bc5976b6050942858f19ad866d5efea650f5e69e9c2d1a47c15706139772
+size 5428053

--- a/Data_2000/Dual_Graphs/Tract2000_37.json
+++ b/Data_2000/Dual_Graphs/Tract2000_37.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eddbc74f555b746bca31c3ead1d240b89bff5b6eabed0f1dab6fcd1e4484f7da
+size 1752309

--- a/Data_2000/Dual_Graphs/Tract2000_38.json
+++ b/Data_2000/Dual_Graphs/Tract2000_38.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f966363a7a9e6df7215ecbc33003824d34a4ff8d3da1400b54de2bf6329b6c4
+size 250625

--- a/Data_2000/Dual_Graphs/Tract2000_39.json
+++ b/Data_2000/Dual_Graphs/Tract2000_39.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f31b3fa49b911a9a37a905cd92d40cbe35ff88ab3a0459a423e50d539281b4a
+size 3269328

--- a/Data_2000/Dual_Graphs/Tract2000_40.json
+++ b/Data_2000/Dual_Graphs/Tract2000_40.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb11631380b1f71d69b4439b9d394f4c94e654abdc00e8adfe889ae18220cb37
+size 1097827

--- a/Data_2000/Dual_Graphs/Tract2000_41.json
+++ b/Data_2000/Dual_Graphs/Tract2000_41.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2289f375d1e85d50dee5602657b393e38ea5d96a99fb1f7c6650257efa22b657
+size 844558

--- a/Data_2000/Dual_Graphs/Tract2000_42.json
+++ b/Data_2000/Dual_Graphs/Tract2000_42.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aac4a3a333cc0123076809c372f6f9100e0e716f3f245d8990493d6b18d2500
+size 3526524

--- a/Data_2000/Dual_Graphs/Tract2000_44.json
+++ b/Data_2000/Dual_Graphs/Tract2000_44.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cabbcb31062380a919e6b679f3b436fedc5c04868c7b8670b3085d2e71b7e7a8
+size 256965

--- a/Data_2000/Dual_Graphs/Tract2000_45.json
+++ b/Data_2000/Dual_Graphs/Tract2000_45.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29192ef0b7632a6a4e2b2425b19eeb4d17bab8fc0fb453b1bbd95f5531bbf735
+size 974011

--- a/Data_2000/Dual_Graphs/Tract2000_46.json
+++ b/Data_2000/Dual_Graphs/Tract2000_46.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5389d6db40a9c34bc5a237877894aa369141da01c1c1734bd08caf05458d8e68
+size 259110

--- a/Data_2000/Dual_Graphs/Tract2000_47.json
+++ b/Data_2000/Dual_Graphs/Tract2000_47.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c59f346ec245d6d8779bdee8ab3f3dfe6eabffa7ce242dd0697faa2de3e2f8c
+size 1408867

--- a/Data_2000/Dual_Graphs/Tract2000_48.json
+++ b/Data_2000/Dual_Graphs/Tract2000_48.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:126b437a565b11186fef1f611df3d049885a1c32fa9895345e91a09201a8bcd0
+size 4833859

--- a/Data_2000/Dual_Graphs/Tract2000_49.json
+++ b/Data_2000/Dual_Graphs/Tract2000_49.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6368e3531fc4569f204c6de51d4aea50ccef4e96fc9b05d1830c938205cb51e2
+size 548255

--- a/Data_2000/Dual_Graphs/Tract2000_50.json
+++ b/Data_2000/Dual_Graphs/Tract2000_50.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d534d5b14278126d7576a7f65910195bbc091bf0a302788b5478eb1d9bc9218b
+size 197471

--- a/Data_2000/Dual_Graphs/Tract2000_51.json
+++ b/Data_2000/Dual_Graphs/Tract2000_51.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:761c9414b4a82e07eebb96fa1c4262fe213ab2553d851359022679a41cf44a44
+size 1701701

--- a/Data_2000/Dual_Graphs/Tract2000_53.json
+++ b/Data_2000/Dual_Graphs/Tract2000_53.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a716cfa265fbfe32c713805e51bde6da37f56f735e1d8a33c4d75dafe56b2fa6
+size 1455917

--- a/Data_2000/Dual_Graphs/Tract2000_54.json
+++ b/Data_2000/Dual_Graphs/Tract2000_54.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5607365add7fb3ecfb4ea088a35800c06755c5fd6b3217768093765940afe182
+size 518443

--- a/Data_2000/Dual_Graphs/Tract2000_55.json
+++ b/Data_2000/Dual_Graphs/Tract2000_55.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a121e73fa20244878fc4c62d58826709aad86c1f8bb4481c94aa350fee5d70b8
+size 1457767

--- a/Data_2000/Dual_Graphs/Tract2000_56.json
+++ b/Data_2000/Dual_Graphs/Tract2000_56.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5551156caae5471bc122ceaac42f6b1aa5a3675bd79dd05cdd33101b4f6bb575
+size 135961

--- a/Data_2000/Dual_Graphs/init.txt
+++ b/Data_2000/Dual_Graphs/init.txt
@@ -1,0 +1,1 @@
+Created Folder

--- a/Data_2000/Shapefiles/Tract2000_01.cpg
+++ b/Data_2000/Shapefiles/Tract2000_01.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_01.dbf
+++ b/Data_2000/Shapefiles/Tract2000_01.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54561d8b0e0b6cf0c751f4b36cf89899145a35c63ede972fbae3fb1993ef00ab
+size 3132939

--- a/Data_2000/Shapefiles/Tract2000_01.prj
+++ b/Data_2000/Shapefiles/Tract2000_01.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_01.shp
+++ b/Data_2000/Shapefiles/Tract2000_01.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4abfc3adf4f1ae084b49fad018a78b850c388da665157c3766ee55a01989fdfa
+size 7348120

--- a/Data_2000/Shapefiles/Tract2000_01.shx
+++ b/Data_2000/Shapefiles/Tract2000_01.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dabb3fd58217cd91fb0c46ad72fe1511ca38aa3d6636601dc84993434dd10291
+size 8748

--- a/Data_2000/Shapefiles/Tract2000_02.cpg
+++ b/Data_2000/Shapefiles/Tract2000_02.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_02.dbf
+++ b/Data_2000/Shapefiles/Tract2000_02.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a028aecfe137871babb163092b911c0baa00b7f1d4b28c9825c145651fc8e51c
+size 459008

--- a/Data_2000/Shapefiles/Tract2000_02.prj
+++ b/Data_2000/Shapefiles/Tract2000_02.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_02.shp
+++ b/Data_2000/Shapefiles/Tract2000_02.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae18dfed20fcc25de5f252740c218ea856fd875b419fa7efca1470ad132c43d9
+size 4816232

--- a/Data_2000/Shapefiles/Tract2000_02.shx
+++ b/Data_2000/Shapefiles/Tract2000_02.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6be94fec3e14d234227eb0dac366769b8b896252de2b827eb3a5ea9c51256c9f
+size 1364

--- a/Data_2000/Shapefiles/Tract2000_04.cpg
+++ b/Data_2000/Shapefiles/Tract2000_04.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_04.dbf
+++ b/Data_2000/Shapefiles/Tract2000_04.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bc70721d100c0db892abf76553c8806f8cd7d07716bbadf9adfe05da1929aef
+size 3208261

--- a/Data_2000/Shapefiles/Tract2000_04.prj
+++ b/Data_2000/Shapefiles/Tract2000_04.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_04.shp
+++ b/Data_2000/Shapefiles/Tract2000_04.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:005a24587aabc222bea9fdb6ea4ff5f956b62b7c6d52e148bdd978a046dff4ee
+size 4662384

--- a/Data_2000/Shapefiles/Tract2000_04.shx
+++ b/Data_2000/Shapefiles/Tract2000_04.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d59b78ecc551a4ea21fabfca859c4f1ff9725fff0d5f0ee0bb5904ff0d44e383
+size 8956

--- a/Data_2000/Shapefiles/Tract2000_05.cpg
+++ b/Data_2000/Shapefiles/Tract2000_05.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_05.dbf
+++ b/Data_2000/Shapefiles/Tract2000_05.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7f8062e5a1fcb80c97faa990f331f3525423dc9716e71c35eba48f7e99d264e
+size 1809010

--- a/Data_2000/Shapefiles/Tract2000_05.prj
+++ b/Data_2000/Shapefiles/Tract2000_05.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_05.shp
+++ b/Data_2000/Shapefiles/Tract2000_05.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a35a81d34fd42d6825543a4ac1efe76fb07822d4f89bf6140a746da832393686
+size 5217328

--- a/Data_2000/Shapefiles/Tract2000_05.shx
+++ b/Data_2000/Shapefiles/Tract2000_05.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c019cf2334b97c639a489f3c80c58c59d21ed87c724cbf496e6b76d833d280fa
+size 5092

--- a/Data_2000/Shapefiles/Tract2000_06.cpg
+++ b/Data_2000/Shapefiles/Tract2000_06.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_06.dbf
+++ b/Data_2000/Shapefiles/Tract2000_06.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:835918e22979814995bb37188163ce1781cd557e183976567d690cb5af0cf1ef
+size 20422235

--- a/Data_2000/Shapefiles/Tract2000_06.prj
+++ b/Data_2000/Shapefiles/Tract2000_06.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_06.shp
+++ b/Data_2000/Shapefiles/Tract2000_06.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce5b0f0230ae1063012d49e0359b054eb416067fc747ad042d8fb94e44f59bfa
+size 16712184

--- a/Data_2000/Shapefiles/Tract2000_06.shx
+++ b/Data_2000/Shapefiles/Tract2000_06.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb1bd5779b5c1220b6a2fdeb4b4adab968218766ad6ba046769c7e1ae4e941c8
+size 56492

--- a/Data_2000/Shapefiles/Tract2000_08.cpg
+++ b/Data_2000/Shapefiles/Tract2000_08.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_08.dbf
+++ b/Data_2000/Shapefiles/Tract2000_08.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36879b412937b8b2ae916bf5135e47356206f5ff711f9097a657f467c7fc6658
+size 3077896

--- a/Data_2000/Shapefiles/Tract2000_08.prj
+++ b/Data_2000/Shapefiles/Tract2000_08.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_08.shp
+++ b/Data_2000/Shapefiles/Tract2000_08.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99d6add86aecd8b878b3077f8c96d46c496adc9728f8952998770c0df2f9c856
+size 4469656

--- a/Data_2000/Shapefiles/Tract2000_08.shx
+++ b/Data_2000/Shapefiles/Tract2000_08.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bcc49b79b826aeb50eb698824c55dce57238e366a1079d584bd03cdc01984fb
+size 8596

--- a/Data_2000/Shapefiles/Tract2000_09.cpg
+++ b/Data_2000/Shapefiles/Tract2000_09.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_09.dbf
+++ b/Data_2000/Shapefiles/Tract2000_09.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7116c989d213f4954c2d853f302e3deb9c194118e5bdcf4c7d2121890b367f8
+size 2362337

--- a/Data_2000/Shapefiles/Tract2000_09.prj
+++ b/Data_2000/Shapefiles/Tract2000_09.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_09.shp
+++ b/Data_2000/Shapefiles/Tract2000_09.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92f263100006948b99a0970501aa6bd7915b64780670af26fdee6dec44f83c04
+size 1452712

--- a/Data_2000/Shapefiles/Tract2000_09.shx
+++ b/Data_2000/Shapefiles/Tract2000_09.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cb9812e7a085f2682cb76cddb9a6a7aae53d69034c2845270b8e3d417db5053
+size 6620

--- a/Data_2000/Shapefiles/Tract2000_10.cpg
+++ b/Data_2000/Shapefiles/Tract2000_10.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_10.dbf
+++ b/Data_2000/Shapefiles/Tract2000_10.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dbfecb1a19636ca20a389f347a68f5ccee8f30ec2214ff25d5950987eafb3b7
+size 571991

--- a/Data_2000/Shapefiles/Tract2000_10.prj
+++ b/Data_2000/Shapefiles/Tract2000_10.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_10.shp
+++ b/Data_2000/Shapefiles/Tract2000_10.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbf488962fb8e8a5f3850dee699c964ec9a1e71407c5425fedc84dde2f3f35ff
+size 590912

--- a/Data_2000/Shapefiles/Tract2000_10.shx
+++ b/Data_2000/Shapefiles/Tract2000_10.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4731ea681c77eab0f657c3e61828ff6a749fe7a3a5a8a379e923a757048540b4
+size 1676

--- a/Data_2000/Shapefiles/Tract2000_11.cpg
+++ b/Data_2000/Shapefiles/Tract2000_11.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_11.dbf
+++ b/Data_2000/Shapefiles/Tract2000_11.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70350eb1af3d873ee463d849dd2a09f75456eb823fa7dcbc7d1a1cffde6446db
+size 545918

--- a/Data_2000/Shapefiles/Tract2000_11.prj
+++ b/Data_2000/Shapefiles/Tract2000_11.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_11.shp
+++ b/Data_2000/Shapefiles/Tract2000_11.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17aa5b5256fdb2302c6e36109e72a44bf2b66b3dcd71d5f272cff64aa721f815
+size 121860

--- a/Data_2000/Shapefiles/Tract2000_11.shx
+++ b/Data_2000/Shapefiles/Tract2000_11.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dc1688bbae72a194dcad47333732b8d11540a4ded5f79a9110dba3efe20ca0d
+size 1604

--- a/Data_2000/Shapefiles/Tract2000_12.cpg
+++ b/Data_2000/Shapefiles/Tract2000_12.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_12.dbf
+++ b/Data_2000/Shapefiles/Tract2000_12.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a82fb09da98cbc5502f3287a06ef75b497e1e97fcfa32afe5098a4a0afbc8c
+size 9135523

--- a/Data_2000/Shapefiles/Tract2000_12.prj
+++ b/Data_2000/Shapefiles/Tract2000_12.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_12.shp
+++ b/Data_2000/Shapefiles/Tract2000_12.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e3ac96bc152a7c424dc455e668e6a5528215be5e2def71e466247bd2fe941c6
+size 10378608

--- a/Data_2000/Shapefiles/Tract2000_12.shx
+++ b/Data_2000/Shapefiles/Tract2000_12.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:149c90ec516014674f07dd6c96469e0c097689468a557b437feb812bdfd0719b
+size 25324

--- a/Data_2000/Shapefiles/Tract2000_13.cpg
+++ b/Data_2000/Shapefiles/Tract2000_13.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_13.dbf
+++ b/Data_2000/Shapefiles/Tract2000_13.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b617a98fbafe71fbd3c7759e755c8b3abc861439ed987ef3a9bf4ce12586d380
+size 4688628

--- a/Data_2000/Shapefiles/Tract2000_13.prj
+++ b/Data_2000/Shapefiles/Tract2000_13.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_13.shp
+++ b/Data_2000/Shapefiles/Tract2000_13.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bed13441f5b4fe96f4ae03ed84ae29c495f58fa396c42d278df32bb442f02f82
+size 8809816

--- a/Data_2000/Shapefiles/Tract2000_13.shx
+++ b/Data_2000/Shapefiles/Tract2000_13.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf3e777bb835208b557a950c9bc601f1a3142b84cc84d294bbdf76b8f9b15b3a
+size 13044

--- a/Data_2000/Shapefiles/Tract2000_15.cpg
+++ b/Data_2000/Shapefiles/Tract2000_15.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_15.dbf
+++ b/Data_2000/Shapefiles/Tract2000_15.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d42bfc039e7042598e74541201bb839aa752be2040551e968692c76b207df77e
+size 829824

--- a/Data_2000/Shapefiles/Tract2000_15.prj
+++ b/Data_2000/Shapefiles/Tract2000_15.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_15.shp
+++ b/Data_2000/Shapefiles/Tract2000_15.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e385307318c6676111e37da4d7a6054d123d86cdfa162947977ff8316dd91a08
+size 1606760

--- a/Data_2000/Shapefiles/Tract2000_15.shx
+++ b/Data_2000/Shapefiles/Tract2000_15.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76931aa2a46e89365b971514a1ac8e14c731de3d0a6e0b7643a4acd79d1bcbca
+size 2388

--- a/Data_2000/Shapefiles/Tract2000_16.cpg
+++ b/Data_2000/Shapefiles/Tract2000_16.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_16.dbf
+++ b/Data_2000/Shapefiles/Tract2000_16.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b5c67f9919cebb92b81e243a5b7313fba94f30efa33c84c7299a4b273aca008
+size 812442

--- a/Data_2000/Shapefiles/Tract2000_16.prj
+++ b/Data_2000/Shapefiles/Tract2000_16.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_16.shp
+++ b/Data_2000/Shapefiles/Tract2000_16.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9fdee55de3cea6e1dc6152374cfdae2053520947341699e679d7a897c9cb3b1
+size 2999340

--- a/Data_2000/Shapefiles/Tract2000_16.shx
+++ b/Data_2000/Shapefiles/Tract2000_16.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff6aa60d057c8a61740ed570da17e77a5302ed81492c8f423ce71926961eef47
+size 2340

--- a/Data_2000/Shapefiles/Tract2000_17.cpg
+++ b/Data_2000/Shapefiles/Tract2000_17.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_17.dbf
+++ b/Data_2000/Shapefiles/Tract2000_17.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc8b4f26a2c05f4cea836f66c2755ecea044c57aedbd256ed9e816b950621bbd
+size 8587990

--- a/Data_2000/Shapefiles/Tract2000_17.prj
+++ b/Data_2000/Shapefiles/Tract2000_17.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_17.shp
+++ b/Data_2000/Shapefiles/Tract2000_17.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:515cc999850b8905bd9c549686f012c60c6ea6f8222246d540d523c53ee120a2
+size 5912204

--- a/Data_2000/Shapefiles/Tract2000_17.shx
+++ b/Data_2000/Shapefiles/Tract2000_17.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:262353f47c1580851f421cb310e4124c2d72c843cf68da2acfa135e0117cafbb
+size 23812

--- a/Data_2000/Shapefiles/Tract2000_18.cpg
+++ b/Data_2000/Shapefiles/Tract2000_18.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_18.dbf
+++ b/Data_2000/Shapefiles/Tract2000_18.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25cfd4bde9dbb80dc3c8c117b4ab7af714dd50b8a3ccdf1256889c0e8cad2967
+size 4091846

--- a/Data_2000/Shapefiles/Tract2000_18.prj
+++ b/Data_2000/Shapefiles/Tract2000_18.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_18.shp
+++ b/Data_2000/Shapefiles/Tract2000_18.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e538061f1acf511e07ef51352038a5eb3f523fab3c1c1e59777d94ce3c7c5a4
+size 3467848

--- a/Data_2000/Shapefiles/Tract2000_18.shx
+++ b/Data_2000/Shapefiles/Tract2000_18.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8688b15332831647eae8b20df747f342ca825f970d312f97a7ad188a983cd4f
+size 11396

--- a/Data_2000/Shapefiles/Tract2000_19.cpg
+++ b/Data_2000/Shapefiles/Tract2000_19.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_19.dbf
+++ b/Data_2000/Shapefiles/Tract2000_19.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c1b0e10f96113aa40700e3af37038ddf817827efb7541fb8e6c9c2afb1374b5
+size 2298603

--- a/Data_2000/Shapefiles/Tract2000_19.prj
+++ b/Data_2000/Shapefiles/Tract2000_19.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_19.shp
+++ b/Data_2000/Shapefiles/Tract2000_19.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4f4ba08f148b1bfb5381cb905123ad86b217ccbd1d68290f787cc02ba296aac
+size 2677344

--- a/Data_2000/Shapefiles/Tract2000_19.shx
+++ b/Data_2000/Shapefiles/Tract2000_19.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1566581209b6215573672bba789f54ee989eb715e7aa70e47ac6e79dce9383c8
+size 6444

--- a/Data_2000/Shapefiles/Tract2000_20.cpg
+++ b/Data_2000/Shapefiles/Tract2000_20.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_20.dbf
+++ b/Data_2000/Shapefiles/Tract2000_20.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19f71ea460e3e8723f4795dd2268f16a714ed21eefde9c64d93f9c9f73a9a279
+size 2107401

--- a/Data_2000/Shapefiles/Tract2000_20.prj
+++ b/Data_2000/Shapefiles/Tract2000_20.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_20.shp
+++ b/Data_2000/Shapefiles/Tract2000_20.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:518c914da719007b350013ef1d4c84e85fa9ec3bd453d1c1eaa57c23c8e218ea
+size 2173444

--- a/Data_2000/Shapefiles/Tract2000_20.shx
+++ b/Data_2000/Shapefiles/Tract2000_20.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d96b69cbdfa700f3ef64d2dc6b7f6821993bb2e2ab080d9389d0143f10386388
+size 5916

--- a/Data_2000/Shapefiles/Tract2000_21.cpg
+++ b/Data_2000/Shapefiles/Tract2000_21.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_21.dbf
+++ b/Data_2000/Shapefiles/Tract2000_21.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a216cf2de088fc695cf4de1eb5404614936afd1b8486d4634bbd72263d3341d7
+size 2880900

--- a/Data_2000/Shapefiles/Tract2000_21.prj
+++ b/Data_2000/Shapefiles/Tract2000_21.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_21.shp
+++ b/Data_2000/Shapefiles/Tract2000_21.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0792f6963ed6946c6e92457d088450ca456b1b8b32faf8946abc10a4af346a9
+size 7228936

--- a/Data_2000/Shapefiles/Tract2000_21.shx
+++ b/Data_2000/Shapefiles/Tract2000_21.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8763c719771c1291d70baf4880f945e949adc0e0163b5deb1e8853fcd9d95a9
+size 8052

--- a/Data_2000/Shapefiles/Tract2000_22.cpg
+++ b/Data_2000/Shapefiles/Tract2000_22.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_22.dbf
+++ b/Data_2000/Shapefiles/Tract2000_22.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79e1f2628165e73d1bb764ba0e812aa0fb9818aa09021bbafe28f43b38affd95
+size 3205364

--- a/Data_2000/Shapefiles/Tract2000_22.prj
+++ b/Data_2000/Shapefiles/Tract2000_22.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_22.shp
+++ b/Data_2000/Shapefiles/Tract2000_22.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35c0a23cbc876d85e646a0dd4690c14b7bed245c11a3aaee0c8610bd15f6bf29
+size 8654144

--- a/Data_2000/Shapefiles/Tract2000_22.shx
+++ b/Data_2000/Shapefiles/Tract2000_22.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87b83031ea40fe4f60fc9ba96a15533433e2bed82edef9c359b8c703c49d22d4
+size 8948

--- a/Data_2000/Shapefiles/Tract2000_23.cpg
+++ b/Data_2000/Shapefiles/Tract2000_23.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_23.dbf
+++ b/Data_2000/Shapefiles/Tract2000_23.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98d1e7d746cb358b04b355baf1ffa0a14faa54a96ae516780992c28f21937b27
+size 997850

--- a/Data_2000/Shapefiles/Tract2000_23.prj
+++ b/Data_2000/Shapefiles/Tract2000_23.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_23.shp
+++ b/Data_2000/Shapefiles/Tract2000_23.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81fbd3f5f37504e1d0327d77196b33c839fe7f9123e4cbc76caeca36180160d0
+size 3247776

--- a/Data_2000/Shapefiles/Tract2000_23.shx
+++ b/Data_2000/Shapefiles/Tract2000_23.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5aa42d7bf1c46e7d0f1eff049ae094cb7ce3e95af669adc50c4c9bbe9353b7cc
+size 2852

--- a/Data_2000/Shapefiles/Tract2000_24.cpg
+++ b/Data_2000/Shapefiles/Tract2000_24.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_24.dbf
+++ b/Data_2000/Shapefiles/Tract2000_24.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dcc0c45a0d10865a6ccfa20b1b4823437609e36aa0f33de0fd3ec74a36f3002
+size 3524034

--- a/Data_2000/Shapefiles/Tract2000_24.prj
+++ b/Data_2000/Shapefiles/Tract2000_24.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_24.shp
+++ b/Data_2000/Shapefiles/Tract2000_24.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e6c6397c76cff0b1f175028061d407b8939ad8838e2d652aa28dccb1471bc21
+size 3599812

--- a/Data_2000/Shapefiles/Tract2000_24.shx
+++ b/Data_2000/Shapefiles/Tract2000_24.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31e8485af2c2e3c23f7dbfdf15b4239600b783194343f0c66752766b51ad06e3
+size 9828

--- a/Data_2000/Shapefiles/Tract2000_25.cpg
+++ b/Data_2000/Shapefiles/Tract2000_25.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_25.dbf
+++ b/Data_2000/Shapefiles/Tract2000_25.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c058eb8a329e38ef26a76da64c21e0e77e1eef95b73c3c4311dd3f394d8e2954
+size 3944099

--- a/Data_2000/Shapefiles/Tract2000_25.prj
+++ b/Data_2000/Shapefiles/Tract2000_25.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_25.shp
+++ b/Data_2000/Shapefiles/Tract2000_25.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:301375e962768dadb646e215a94cbf0178cfa02803fd49925eddee0b6da7f349
+size 2963784

--- a/Data_2000/Shapefiles/Tract2000_25.shx
+++ b/Data_2000/Shapefiles/Tract2000_25.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7ca765dd0d5efe90ba52c2a62e69e99fe9547123b5329b95db51d304e164e1d
+size 10988

--- a/Data_2000/Shapefiles/Tract2000_26.cpg
+++ b/Data_2000/Shapefiles/Tract2000_26.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_26.dbf
+++ b/Data_2000/Shapefiles/Tract2000_26.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb219f5840bc6d9cdff286f728b1f90c596883756011555454bf421dd75f95e1
+size 7869534

--- a/Data_2000/Shapefiles/Tract2000_26.prj
+++ b/Data_2000/Shapefiles/Tract2000_26.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_26.shp
+++ b/Data_2000/Shapefiles/Tract2000_26.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:068d56c1f5159c1c150ae03b451010d0638ff861d3b8228704a3d4928d911d04
+size 6165476

--- a/Data_2000/Shapefiles/Tract2000_26.shx
+++ b/Data_2000/Shapefiles/Tract2000_26.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:105ac40eea2e30d3e417d59b652c24febe38b1725f2bb82e9f4418c999f713ee
+size 21828

--- a/Data_2000/Shapefiles/Tract2000_27.cpg
+++ b/Data_2000/Shapefiles/Tract2000_27.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_27.dbf
+++ b/Data_2000/Shapefiles/Tract2000_27.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e150d070cd4b654032b4835dd3b8a69b06333a5929757b67562f732648e430b0
+size 3767382

--- a/Data_2000/Shapefiles/Tract2000_27.prj
+++ b/Data_2000/Shapefiles/Tract2000_27.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_27.shp
+++ b/Data_2000/Shapefiles/Tract2000_27.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ea541e874bc6c8a30e9f8d9c6b80140ec452f3733aedd4d0cbe6282fea4805
+size 4385020

--- a/Data_2000/Shapefiles/Tract2000_27.shx
+++ b/Data_2000/Shapefiles/Tract2000_27.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a5408961a52f1f496b4bc1fbac3a1e3238b91e5317bccbdd2d0b9ddc0e699ba
+size 10500

--- a/Data_2000/Shapefiles/Tract2000_28.cpg
+++ b/Data_2000/Shapefiles/Tract2000_28.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_28.dbf
+++ b/Data_2000/Shapefiles/Tract2000_28.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a655556991f9922bbfe193aff970b5e1519bd0152c28b103a1a9ed8ec171379
+size 1753967

--- a/Data_2000/Shapefiles/Tract2000_28.prj
+++ b/Data_2000/Shapefiles/Tract2000_28.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_28.shp
+++ b/Data_2000/Shapefiles/Tract2000_28.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ac53db61d52f9b6afee7106bf457a661145b9e7fc50dcd4ba96e1506f069941
+size 4198936

--- a/Data_2000/Shapefiles/Tract2000_28.shx
+++ b/Data_2000/Shapefiles/Tract2000_28.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:487f5a2deea4fa1ec6bd4c0bfe3569f954fdffa33fed3311bcab407fcfd2a195
+size 4940

--- a/Data_2000/Shapefiles/Tract2000_29.cpg
+++ b/Data_2000/Shapefiles/Tract2000_29.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_29.dbf
+++ b/Data_2000/Shapefiles/Tract2000_29.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a68c9efab53ef0c7a5342ceac02c2679bf6016917f91fc9d044a1f31cc59ba2
+size 3825322

--- a/Data_2000/Shapefiles/Tract2000_29.prj
+++ b/Data_2000/Shapefiles/Tract2000_29.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_29.shp
+++ b/Data_2000/Shapefiles/Tract2000_29.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5d3f7cd265a653a1964f49ecc9235ef246bcf834873848ae7e771ad75a776fc
+size 5574536

--- a/Data_2000/Shapefiles/Tract2000_29.shx
+++ b/Data_2000/Shapefiles/Tract2000_29.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54a6fe8e712de3dbd39928792353a2020119d94b475c27d2e17bf6887f4374d1
+size 10660

--- a/Data_2000/Shapefiles/Tract2000_30.cpg
+++ b/Data_2000/Shapefiles/Tract2000_30.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_30.dbf
+++ b/Data_2000/Shapefiles/Tract2000_30.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d78c59de909ddce07fc0ba5bccedd5f979b0125999f883d8b4188ac67ab7af2
+size 783472

--- a/Data_2000/Shapefiles/Tract2000_30.prj
+++ b/Data_2000/Shapefiles/Tract2000_30.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_30.shp
+++ b/Data_2000/Shapefiles/Tract2000_30.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6229b0135276159c3f3583a9db091082f75f178c850ed8a1fde70038f6087aa2
+size 4430940

--- a/Data_2000/Shapefiles/Tract2000_30.shx
+++ b/Data_2000/Shapefiles/Tract2000_30.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87ba9d4ca5f864b9599dbb6845ed7dadb7de10054b098386255c2bd88983f1a4
+size 2260

--- a/Data_2000/Shapefiles/Tract2000_31.cpg
+++ b/Data_2000/Shapefiles/Tract2000_31.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_31.dbf
+++ b/Data_2000/Shapefiles/Tract2000_31.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14bb7fdc63d48dcee8daddead4120d4a46155248767d7dffb2c1acd1f3b08c31
+size 1458473

--- a/Data_2000/Shapefiles/Tract2000_31.prj
+++ b/Data_2000/Shapefiles/Tract2000_31.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_31.shp
+++ b/Data_2000/Shapefiles/Tract2000_31.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d5c7d31febb63d8b6be0a42f565fb939f7f6012a867024109f7d8978ba8eff
+size 1712924

--- a/Data_2000/Shapefiles/Tract2000_31.shx
+++ b/Data_2000/Shapefiles/Tract2000_31.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cd4997c4cc97bf05c1eee0551d4eadeb5eecc970a53cd7d3bc44adfd96c7574
+size 4124

--- a/Data_2000/Shapefiles/Tract2000_32.cpg
+++ b/Data_2000/Shapefiles/Tract2000_32.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_32.dbf
+++ b/Data_2000/Shapefiles/Tract2000_32.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67bfce8d4de423443119cde4fa5cc07d604a0232d704647eb76902d22fc176fa
+size 1412121

--- a/Data_2000/Shapefiles/Tract2000_32.prj
+++ b/Data_2000/Shapefiles/Tract2000_32.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_32.shp
+++ b/Data_2000/Shapefiles/Tract2000_32.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:673bb1e1de033ab85d1f02e8f720474c2e25260744e14610d648227105fc9f1e
+size 1755264

--- a/Data_2000/Shapefiles/Tract2000_32.shx
+++ b/Data_2000/Shapefiles/Tract2000_32.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f213c1d9e1180f37e385e5ea5a8dd6de2c46846d31895d360061d21c203a1cf
+size 3996

--- a/Data_2000/Shapefiles/Tract2000_33.cpg
+++ b/Data_2000/Shapefiles/Tract2000_33.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_33.dbf
+++ b/Data_2000/Shapefiles/Tract2000_33.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b0a9cf4c43b85ba95c01d044885eaf1fb22af1c9aaa6a7be31164731ebf2bd
+size 789266

--- a/Data_2000/Shapefiles/Tract2000_33.prj
+++ b/Data_2000/Shapefiles/Tract2000_33.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_33.shp
+++ b/Data_2000/Shapefiles/Tract2000_33.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1728711d1541eb89b7ea634e31f8b98b291407291592b33401702d4aad7854c8
+size 784256

--- a/Data_2000/Shapefiles/Tract2000_33.shx
+++ b/Data_2000/Shapefiles/Tract2000_33.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae740fe5881de5df45d5731fca87f6cd4cf925a7bf1165283f6d48f7e4c630bc
+size 2276

--- a/Data_2000/Shapefiles/Tract2000_34.cpg
+++ b/Data_2000/Shapefiles/Tract2000_34.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_34.dbf
+++ b/Data_2000/Shapefiles/Tract2000_34.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e579831243954d77f679d04c6fc6b233e1995fd2552d418d4d1b064668aec3
+size 5633050

--- a/Data_2000/Shapefiles/Tract2000_34.prj
+++ b/Data_2000/Shapefiles/Tract2000_34.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_34.shp
+++ b/Data_2000/Shapefiles/Tract2000_34.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f519fd5a1bef14667615e7299a60dc32b01331f32ce7c39d53afaaad4a63c372
+size 3508712

--- a/Data_2000/Shapefiles/Tract2000_34.shx
+++ b/Data_2000/Shapefiles/Tract2000_34.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6322226f8d724c79f8346aca59d6078cdd36047ebac9a6ff5503b3bc5ff3439
+size 15652

--- a/Data_2000/Shapefiles/Tract2000_35.cpg
+++ b/Data_2000/Shapefiles/Tract2000_35.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_35.dbf
+++ b/Data_2000/Shapefiles/Tract2000_35.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0923c126699aaf04715bc2ce21bdadb9ebfd4e4418292f855e073de95e870ff5
+size 1322314

--- a/Data_2000/Shapefiles/Tract2000_35.prj
+++ b/Data_2000/Shapefiles/Tract2000_35.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_35.shp
+++ b/Data_2000/Shapefiles/Tract2000_35.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ad423d37bb4107a429de2388425aa7b240a451eb2ce506964cd24a9d85e4d8d
+size 2945336

--- a/Data_2000/Shapefiles/Tract2000_35.shx
+++ b/Data_2000/Shapefiles/Tract2000_35.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6990bf51e61a39eefd18ede5b48c81267f97c26531385eda058592f3c9e7c93c
+size 3748

--- a/Data_2000/Shapefiles/Tract2000_36.cpg
+++ b/Data_2000/Shapefiles/Tract2000_36.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_36.dbf
+++ b/Data_2000/Shapefiles/Tract2000_36.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e856fe81038e088b04aebb8256cf3caabf7602842f43b949f21b99898fa84533
+size 14156024

--- a/Data_2000/Shapefiles/Tract2000_36.prj
+++ b/Data_2000/Shapefiles/Tract2000_36.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_36.shp
+++ b/Data_2000/Shapefiles/Tract2000_36.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01d1ea6fc6a52ec00f26ac5b2fce44318f79abc3923db8b6e95754c5cc34aa08
+size 7595016

--- a/Data_2000/Shapefiles/Tract2000_36.shx
+++ b/Data_2000/Shapefiles/Tract2000_36.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c340911a8285712e6321ae83519cd632ee84eaa356db2db37a09ee4948159e9f
+size 39188

--- a/Data_2000/Shapefiles/Tract2000_37.cpg
+++ b/Data_2000/Shapefiles/Tract2000_37.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_37.dbf
+++ b/Data_2000/Shapefiles/Tract2000_37.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8fed03933dcff6b534b784d300f09db915f60afdb57ecd75d8e44bba5e8d3d
+size 4506117

--- a/Data_2000/Shapefiles/Tract2000_37.prj
+++ b/Data_2000/Shapefiles/Tract2000_37.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_37.shp
+++ b/Data_2000/Shapefiles/Tract2000_37.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed29b0134d7319172e5cae9cf8027d46bfc058259f8e12f7de4ed9b34f9f3173
+size 10728404

--- a/Data_2000/Shapefiles/Tract2000_37.shx
+++ b/Data_2000/Shapefiles/Tract2000_37.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1180f4f616b63b0145be87ff3bbde80ff350671d8c283a2809cdf7ce14e70739
+size 12540

--- a/Data_2000/Shapefiles/Tract2000_38.cpg
+++ b/Data_2000/Shapefiles/Tract2000_38.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_38.dbf
+++ b/Data_2000/Shapefiles/Tract2000_38.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ae66c0ee0feb85d49b623b3c72fb50774c4390f7dedb5f216896f28276e963
+size 658901

--- a/Data_2000/Shapefiles/Tract2000_38.prj
+++ b/Data_2000/Shapefiles/Tract2000_38.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_38.shp
+++ b/Data_2000/Shapefiles/Tract2000_38.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2f1c6fc1b4c4dd75695565be234e88b697d9220a4ec531e5c06dfd4ca8edb26
+size 1547780

--- a/Data_2000/Shapefiles/Tract2000_38.shx
+++ b/Data_2000/Shapefiles/Tract2000_38.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dcf3279243a41f6712d520d25058a2b4aef40ea43c888ef81cb59ea4b76f51a
+size 1916

--- a/Data_2000/Shapefiles/Tract2000_39.cpg
+++ b/Data_2000/Shapefiles/Tract2000_39.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_39.dbf
+++ b/Data_2000/Shapefiles/Tract2000_39.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c02e2c2268c116ace12bc295b38eb0a57f0a893a7b1bec0f3e698ab7f477590b
+size 8501080

--- a/Data_2000/Shapefiles/Tract2000_39.prj
+++ b/Data_2000/Shapefiles/Tract2000_39.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_39.shp
+++ b/Data_2000/Shapefiles/Tract2000_39.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58f7ac626c4765dfbbad9f73b59e6f98fdc8972cbec18f98663c17130f42764c
+size 5825972

--- a/Data_2000/Shapefiles/Tract2000_39.shx
+++ b/Data_2000/Shapefiles/Tract2000_39.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b839b43153cf38585c08217734afbe4653b1556bdcf0bb81ba3018bbc0028f8f
+size 23572

--- a/Data_2000/Shapefiles/Tract2000_40.cpg
+++ b/Data_2000/Shapefiles/Tract2000_40.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_40.dbf
+++ b/Data_2000/Shapefiles/Tract2000_40.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5906e66e60429ab91a3664da5b875ce26a0ef2ea6d2eb04a282bc7be02c7873f
+size 2869312

--- a/Data_2000/Shapefiles/Tract2000_40.prj
+++ b/Data_2000/Shapefiles/Tract2000_40.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_40.shp
+++ b/Data_2000/Shapefiles/Tract2000_40.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b118599a2070f3c7514535be309162a303b60943584b47c0aa16bf389569f627
+size 4217008

--- a/Data_2000/Shapefiles/Tract2000_40.shx
+++ b/Data_2000/Shapefiles/Tract2000_40.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2665204df968e28ae9abc3900e30e71bda03b36e1bee2bd14561901af259b75a
+size 8020

--- a/Data_2000/Shapefiles/Tract2000_41.cpg
+++ b/Data_2000/Shapefiles/Tract2000_41.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_41.dbf
+++ b/Data_2000/Shapefiles/Tract2000_41.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:810c908636efe5400bd240481f7dfbeee1dd8ef2cac7816846ad5b7567ab2649
+size 2188517

--- a/Data_2000/Shapefiles/Tract2000_41.prj
+++ b/Data_2000/Shapefiles/Tract2000_41.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_41.shp
+++ b/Data_2000/Shapefiles/Tract2000_41.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c043aafec44e74db4b2cc940a7eb7430f6c4c60ba7a9aafb3ab1e5a2147e3207
+size 5526896

--- a/Data_2000/Shapefiles/Tract2000_41.shx
+++ b/Data_2000/Shapefiles/Tract2000_41.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:270fb7c8c54ba084c9f152c1643157e1b4d983a2fbc27e2cda2e507d56248447
+size 6140

--- a/Data_2000/Shapefiles/Tract2000_42.cpg
+++ b/Data_2000/Shapefiles/Tract2000_42.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_42.dbf
+++ b/Data_2000/Shapefiles/Tract2000_42.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2620aee5af871ca9f77274892850f359a772a1cfe6af88a245c3d9f4786a5e0
+size 9080480

--- a/Data_2000/Shapefiles/Tract2000_42.prj
+++ b/Data_2000/Shapefiles/Tract2000_42.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_42.shp
+++ b/Data_2000/Shapefiles/Tract2000_42.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb6d8765eb6cba2602612593f86fb0d64915d3a1aee496ef2b474d15a1a83dd9
+size 7788072

--- a/Data_2000/Shapefiles/Tract2000_42.shx
+++ b/Data_2000/Shapefiles/Tract2000_42.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f803672bcedde63085fafed312b26ae0bd26252a8dfd494ac0c962bdb240cdf
+size 25172

--- a/Data_2000/Shapefiles/Tract2000_44.cpg
+++ b/Data_2000/Shapefiles/Tract2000_44.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_44.dbf
+++ b/Data_2000/Shapefiles/Tract2000_44.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:761f5c62c0c3e064ebf7ed2b3f64f515e43bb5f9998796e557cd3467a7a7a01c
+size 676283

--- a/Data_2000/Shapefiles/Tract2000_44.prj
+++ b/Data_2000/Shapefiles/Tract2000_44.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_44.shp
+++ b/Data_2000/Shapefiles/Tract2000_44.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9c90d3a9a3316393b15e59603ee3f59af636f9898ec4631eb7c6a847db9d619
+size 569740

--- a/Data_2000/Shapefiles/Tract2000_44.shx
+++ b/Data_2000/Shapefiles/Tract2000_44.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7540db39a8735947c6569ca4372a93fad94890b15ab8f1534055be98a1e9062e
+size 1964

--- a/Data_2000/Shapefiles/Tract2000_45.cpg
+++ b/Data_2000/Shapefiles/Tract2000_45.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_45.dbf
+++ b/Data_2000/Shapefiles/Tract2000_45.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa3178aa0e123ac6f731001c9e83586f1108897a5bcabebcb2a1c62660c267e4
+size 2512981

--- a/Data_2000/Shapefiles/Tract2000_45.prj
+++ b/Data_2000/Shapefiles/Tract2000_45.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_45.shp
+++ b/Data_2000/Shapefiles/Tract2000_45.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1add78ccf13a8d207fd3e86025c5c2ea13342eab44fc48eac8e0851f12640db0
+size 6173852

--- a/Data_2000/Shapefiles/Tract2000_45.shx
+++ b/Data_2000/Shapefiles/Tract2000_45.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc09a74adebbfbb4b5600b9d0e036a9af890a3434affb3ef4220d499d60921b6
+size 7036

--- a/Data_2000/Shapefiles/Tract2000_46.cpg
+++ b/Data_2000/Shapefiles/Tract2000_46.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_46.dbf
+++ b/Data_2000/Shapefiles/Tract2000_46.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f324f83e670621b41b102a62bcb8402fab95336967dbaffcb50108613e2f5bd2
+size 682077

--- a/Data_2000/Shapefiles/Tract2000_46.prj
+++ b/Data_2000/Shapefiles/Tract2000_46.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_46.shp
+++ b/Data_2000/Shapefiles/Tract2000_46.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381ff9d38892c84db6cb89507016d42425b0d4c2100cad06c474e4731f93ba68
+size 1741468

--- a/Data_2000/Shapefiles/Tract2000_46.shx
+++ b/Data_2000/Shapefiles/Tract2000_46.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69bce3ffaacbd3fcdfe3a2eb7da0d14cf685dba5897ee64a85e519c09856bd78
+size 1980

--- a/Data_2000/Shapefiles/Tract2000_47.cpg
+++ b/Data_2000/Shapefiles/Tract2000_47.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_47.dbf
+++ b/Data_2000/Shapefiles/Tract2000_47.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f392cf5da7472f5c111557bc0789f9bdbad6df6d37b4af5d22fef7219f10f20c
+size 3654399

--- a/Data_2000/Shapefiles/Tract2000_47.prj
+++ b/Data_2000/Shapefiles/Tract2000_47.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_47.shp
+++ b/Data_2000/Shapefiles/Tract2000_47.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de30226671ce2cbf6df4750568c158966f10262ad209a250bf57213cd6ebdfa7
+size 7041512

--- a/Data_2000/Shapefiles/Tract2000_47.shx
+++ b/Data_2000/Shapefiles/Tract2000_47.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:813217466a39ef39d8b35d3aed8f5560122ef9036e31e293ef6a101017540bda
+size 10188

--- a/Data_2000/Shapefiles/Tract2000_48.cpg
+++ b/Data_2000/Shapefiles/Tract2000_48.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_48.dbf
+++ b/Data_2000/Shapefiles/Tract2000_48.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dca602527b754c4bf5a11a65c5091c94af02c444f575b1e475e773c3a8871f35
+size 12713318

--- a/Data_2000/Shapefiles/Tract2000_48.prj
+++ b/Data_2000/Shapefiles/Tract2000_48.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_48.shp
+++ b/Data_2000/Shapefiles/Tract2000_48.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af6bd2739a89ac161005d82af5810f6a04081b0aafe73fbf8a61fffbac004a3
+size 20097064

--- a/Data_2000/Shapefiles/Tract2000_48.shx
+++ b/Data_2000/Shapefiles/Tract2000_48.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa1170b027bb4e1c47f035fabe48fcc8896892ec9a0996271c7d86961dfb3259
+size 35204

--- a/Data_2000/Shapefiles/Tract2000_49.cpg
+++ b/Data_2000/Shapefiles/Tract2000_49.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_49.dbf
+++ b/Data_2000/Shapefiles/Tract2000_49.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255db18cfa0a8a3e45b6ef60ed55fd9fc2f58253813fb1fe9b6454e0a3c9e5bb
+size 1438194

--- a/Data_2000/Shapefiles/Tract2000_49.prj
+++ b/Data_2000/Shapefiles/Tract2000_49.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_49.shp
+++ b/Data_2000/Shapefiles/Tract2000_49.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0149a910a4d4c9c2255e9c2dcea5bfdfaffa4a2215d49d14ec374e37dd1349f
+size 3070732

--- a/Data_2000/Shapefiles/Tract2000_49.shx
+++ b/Data_2000/Shapefiles/Tract2000_49.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c58d97f1e11c1fa55415d6939fa8372223049953da1e5025aaf0bcfa5407460a
+size 4068

--- a/Data_2000/Shapefiles/Tract2000_50.cpg
+++ b/Data_2000/Shapefiles/Tract2000_50.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_50.dbf
+++ b/Data_2000/Shapefiles/Tract2000_50.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce78adbe7e4e550ada7ca526d4baaa53fafc80f9005227db5b091b0c83f75ffb
+size 519845

--- a/Data_2000/Shapefiles/Tract2000_50.prj
+++ b/Data_2000/Shapefiles/Tract2000_50.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_50.shp
+++ b/Data_2000/Shapefiles/Tract2000_50.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797e924bf3ae0952dbf30f662b3f9bfef126338b70f81417ab9d70ff520f0957
+size 564008

--- a/Data_2000/Shapefiles/Tract2000_50.shx
+++ b/Data_2000/Shapefiles/Tract2000_50.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2fe15d5c1744bf17cf054c3e589698db94debd5672e09b428656848340bed17
+size 1532

--- a/Data_2000/Shapefiles/Tract2000_51.cpg
+++ b/Data_2000/Shapefiles/Tract2000_51.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_51.dbf
+++ b/Data_2000/Shapefiles/Tract2000_51.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe894ed02bd140c166d9fdaf82bc20b4e46cd00d2d046b88767f2bb8f2103afa
+size 4433692

--- a/Data_2000/Shapefiles/Tract2000_51.prj
+++ b/Data_2000/Shapefiles/Tract2000_51.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_51.shp
+++ b/Data_2000/Shapefiles/Tract2000_51.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e5662f7552d305d960ad65fc6cb9b82079fb18694fb18936943c40febc7c045
+size 8413404

--- a/Data_2000/Shapefiles/Tract2000_51.shx
+++ b/Data_2000/Shapefiles/Tract2000_51.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713467b14c5723a8b6e14ef194b3699d090dceec2ce0745d54377cda609b40a9
+size 12340

--- a/Data_2000/Shapefiles/Tract2000_53.cpg
+++ b/Data_2000/Shapefiles/Tract2000_53.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_53.dbf
+++ b/Data_2000/Shapefiles/Tract2000_53.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7429a780f93fc90b5a27085ad740bdb54ea748cfe2a6ed8c9a0e34c37857be5
+size 3819528

--- a/Data_2000/Shapefiles/Tract2000_53.prj
+++ b/Data_2000/Shapefiles/Tract2000_53.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_53.shp
+++ b/Data_2000/Shapefiles/Tract2000_53.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8af407e91067261d98210d72a112cbb35e81ee57e896136fc6f2d63ce4f4a81
+size 6276856

--- a/Data_2000/Shapefiles/Tract2000_53.shx
+++ b/Data_2000/Shapefiles/Tract2000_53.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0cdd44d76a19bb01775ad70fc88a2a36667d584a4a927d515ab6e76f13d27a8
+size 10644

--- a/Data_2000/Shapefiles/Tract2000_54.cpg
+++ b/Data_2000/Shapefiles/Tract2000_54.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_54.dbf
+++ b/Data_2000/Shapefiles/Tract2000_54.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3828c588b8c9547c9bcfb6267b9eb5da11f4e9c61aedfc4a1c3c2d61e795c5c2
+size 1351284

--- a/Data_2000/Shapefiles/Tract2000_54.prj
+++ b/Data_2000/Shapefiles/Tract2000_54.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_54.shp
+++ b/Data_2000/Shapefiles/Tract2000_54.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:417a14aa88c09eef65a936c79f80fc25a853a0226c23453d24029382a5103cce
+size 4401164

--- a/Data_2000/Shapefiles/Tract2000_54.shx
+++ b/Data_2000/Shapefiles/Tract2000_54.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f60c562772b8e5a2202a0d36328301476efebe8c1e77d00c3dc759c833276226
+size 3828

--- a/Data_2000/Shapefiles/Tract2000_55.cpg
+++ b/Data_2000/Shapefiles/Tract2000_55.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_55.dbf
+++ b/Data_2000/Shapefiles/Tract2000_55.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57bbf97a683cd7865b9c2041fcbd4506df0a727639e1cee194866b78a5762bfd
+size 3825322

--- a/Data_2000/Shapefiles/Tract2000_55.prj
+++ b/Data_2000/Shapefiles/Tract2000_55.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_55.shp
+++ b/Data_2000/Shapefiles/Tract2000_55.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ff8882c9a250a235dfdec66a662a145d862a4176066999583252885707aa1cd
+size 4547404

--- a/Data_2000/Shapefiles/Tract2000_55.shx
+++ b/Data_2000/Shapefiles/Tract2000_55.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fb60422f8fb42c455ec4bc7c2253cf48a8690d41d4942d5e9add93bc982ce7
+size 10660

--- a/Data_2000/Shapefiles/Tract2000_56.cpg
+++ b/Data_2000/Shapefiles/Tract2000_56.cpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fc313075748ce8ead962229ed89c919d5a9ff71974ee725a0b48bb87d975a2
+size 10

--- a/Data_2000/Shapefiles/Tract2000_56.dbf
+++ b/Data_2000/Shapefiles/Tract2000_56.dbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26594629b8b54b85c9afa2cbbc7147f542c82231cb91c2a5dc9e36ed97e4857
+size 369201

--- a/Data_2000/Shapefiles/Tract2000_56.prj
+++ b/Data_2000/Shapefiles/Tract2000_56.prj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96208a6c67e2538a49148cb3a6cb5c36e0f4dbd6390250333378dc0d90423783
+size 411

--- a/Data_2000/Shapefiles/Tract2000_56.shp
+++ b/Data_2000/Shapefiles/Tract2000_56.shp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d11d4805654c66de2ef2c3701dbe5cc057b1f0c57a4ca0af942219127bc8297
+size 1620840

--- a/Data_2000/Shapefiles/Tract2000_56.shx
+++ b/Data_2000/Shapefiles/Tract2000_56.shx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0bc6013e63b06b9048cf864a0b43a8cef9d875e06c62fba7a2a0f0b5a9f8458
+size 1116

--- a/Data_2000/Shapefiles/init.txt
+++ b/Data_2000/Shapefiles/init.txt
@@ -1,0 +1,1 @@
+Created Folder

--- a/Generate_Ensembles.py
+++ b/Generate_Ensembles.py
@@ -19,7 +19,7 @@ from gerrychain import Graph
 state_fips = '49'
 num_districts = 4
 
-newdir = f"./Tract_Ensemble/{state_fips}/"
+newdir = f"./Tract_Ensemble/2000/{state_fips}/"
 os.makedirs(os.path.dirname(newdir + "init.txt"), exist_ok=True)
 with open(newdir + "init.txt", "w") as f:
     f.write("Created Folder")
@@ -31,15 +31,16 @@ with open(newdir + "init.txt", "w") as f:
 from gerrychain import Graph, Partition, Election
 from gerrychain.updaters import Tally, cut_edges
 
-graph = Graph.from_json(f'./TRACT_DATA/TRACT_{state_fips}.json')
+graph = Graph.from_json(f'./Data_2000/Dual_Graphs/Tract2000_{state_fips}.json')
 
 totpop = 0
 
 for n in graph.nodes():
-    totpop += graph.nodes[n]["TOTPOP"]
+    graph.nodes[n]["FL5001"] = int(graph.nodes[n]["FL5001"])
+    totpop += graph.nodes[n]["FL5001"]
 
 cddict =  recursive_tree_part(graph, range(num_districts), 
-                                          totpop / num_districts, "TOTPOP", .02, 1)
+                                          totpop / num_districts, "FL5001", .02, 1)
 
             
 for node in graph.nodes():
@@ -48,14 +49,12 @@ for node in graph.nodes():
 graph.to_json(newdir + 'starting_plan.json')
 
 
-
-
 initial_partition = Partition(
     graph,
     assignment='New_Seed',
     updaters={
         "cut_edges": cut_edges,
-        "population": Tally("TOTPOP", alias="population"),
+        "population": Tally("FL5001", alias="population"),
     }
 )
 
@@ -159,7 +158,7 @@ ideal_population = sum(initial_partition["population"].values()) / len(
 )
 
 proposal = partial(
-    recom, pop_col="TOTPOP", pop_target=ideal_population, epsilon=0.01, node_repeats=1, method =my_uu_bipartition_tree_random)
+    recom, pop_col="FL5001", pop_target=ideal_population, epsilon=0.01, node_repeats=1, method =my_uu_bipartition_tree_random)
     
 threshold = 0.02
     

--- a/Process_Tracts.py
+++ b/Process_Tracts.py
@@ -1,0 +1,54 @@
+import geopandas as gpd
+import os
+import pickle
+import numpy as np
+import gerrychain as gc
+from gerrychain import Graph
+from gerrychain.tree import recursive_tree_part
+
+all_tracts = gpd.read_file("./Tracts_2000_wPop.shp")
+
+
+
+centroids = all_tracts.centroid
+
+
+os.makedirs(os.path.dirname("./Data/Shapefiles/init.txt"), exist_ok=True)
+with open("./Data/Shapefiles/init.txt", "w") as f:
+    f.write("Created Folder")
+    
+os.makedirs(os.path.dirname("./Data/Dual_Graphs/init.txt"), exist_ok=True)
+with open("./Data/Dual_Graphs/init.txt", "w") as f:
+    f.write("Created Folder")
+
+all_tracts["C_X"] = centroids.x
+all_tracts["C_Y"] = centroids.y
+
+all_tracts = all_tracts[all_tracts["GISJOIN"] != "G3600130nodata"]
+#Remove weird NY Tract with no data. 
+
+states = all_tracts["STATEA"].unique()
+
+all_tracts["GEOID"] = (all_tracts["STATEA"].astype(int)).astype(str)+all_tracts["COUNTYA"]+all_tracts["TRACTA"]
+
+
+for fips in states:
+
+    print(f"Starting {fips}")
+    
+    if not os.path.exists(f"./Data/Dual_Graphs/Tract2000_{fips}.json"):
+        state_tracts = all_tracts[all_tracts["STATEA"]==fips]
+        
+        if fips == '06':
+            
+            state_tracts["geometry"] = state_tracts.geometry.buffer(0)
+        
+        state_graph = Graph.from_geodataframe(state_tracts, ignore_errors = True)
+        
+        state_graph.add_data(state_tracts)
+        
+        state_tracts.to_file(f"./Data/Shapefiles/Tract2000_{fips}.shp")
+        
+        state_graph.to_json(f"./Data/Dual_Graphs/Tract2000_{fips}.json")
+    
+    


### PR DESCRIPTION
Add shapefiles and dual graphs for 2000 Tracts

Added processing script that was used to build the individual state files from raw data

Adjust Generate_Ensembles.py to point at the new dual graphs and use the new population column names.